### PR TITLE
Bugfixes, bump to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sensorlog"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sensorlog"
 description = "A lightweight data logging service"
 repository = "https://github.com/nyantec.sensorlog"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["The sensorlog Authors <oss@nyantec.com>"]
 license = "MirOS"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ impl Sensorlog {
 		Ok(measurements)
 	}
 
-	pub fn set_storage_quota_for(&mut self, sensor_id: &str, quota: ::quota::StorageQuota) {
+	pub fn set_storage_quota_for(&mut self, sensor_id: &str, quota: ::quota::StorageQuota) -> Result<(), Error> {
 		let logfile_id = LogfileID::from_string(sensor_id.to_string());
 		self.logfile_map.set_storage_quota_for(&logfile_id, quota)
 	}

--- a/src/logfile.rs
+++ b/src/logfile.rs
@@ -173,6 +173,21 @@ impl Logfile {
 		let reader = LogfileReader::new(&storage_locked.partitions);
 		reader.fetch_measurements(time_start, time_limit, limit)
 	}
+
+	pub fn set_storage_quota(&self, quota: StorageQuota) -> Result<(), ::Error> {
+		if quota.is_zero() {
+			return Err(err_quota!("insufficient quota"));
+		}
+
+		// lock the storage
+		let mut storage_locked = match self.storage.write() {
+			Ok(l) => l,
+			Err(_) => fatal!("lock is poisoned"),
+		};
+		storage_locked.storage_quota = quota;
+
+		Ok(())
+	}
 }
 
 impl LogfileStorage {

--- a/src/logfile.rs
+++ b/src/logfile.rs
@@ -150,8 +150,13 @@ impl Logfile {
 		storage_locked.allocate(measurement_size)?;
 
 		// insert the new measurement into the head partition
-		match storage_locked.partitions.last_mut() {
-			Some(p) => p.append_measurement(measurement)?,
+		match &mut storage_locked.partitions.last_mut() {
+			Some(p) => {
+				p.append_measurement(measurement)?;
+				let part_name = p.get_file_name();
+				// Make sure that the currently used partition is not in self.deleted_partition
+				storage_locked.partitions_deleted.retain(|x| x.get_file_name() != part_name);
+			},
 			None => return Err(err_server!("corrupt partition map")),
 		};
 

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -19,7 +19,7 @@
  * of said person’s immediate fault when using the work as intended.
  */
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum StorageQuota {
 	Unlimited,
 	Limited { limit_bytes: u64 },


### PR DESCRIPTION
This PR fixes two bugs:
1. Do not remove logfiles from the logfile map if their quota is updated. This lead to us removing all data from the sensor if the quota was changed at runtime.
2. When appending a measurement, do not remove the logfile partition we just wrote to. This bug was triggered, when a storage quota < partition_size_bytes_default was set. The garbage collection marked the '0' partition to be deleted. After that the file was written, and then the marked partitions deleted, removing the just written data and leading to a corrupt storage.